### PR TITLE
Migrate AWS infrastructure to OCI

### DIFF
--- a/infrastructure/OCI_MIGRATION_README.md
+++ b/infrastructure/OCI_MIGRATION_README.md
@@ -1,0 +1,258 @@
+# AWS to OCI Migration Guide
+
+This document outlines the migration of the high-level AWS infrastructure setup (RabbitMQ and Redis servers with load balancers, HAProxy, and monitoring) to Oracle Cloud Infrastructure (OCI).
+
+## Overview
+
+The original AWS setup included:
+- **Redis Cluster**: 6 EC2 instances across 3 availability zones
+- **RabbitMQ HA**: 2 EC2 instances with HAProxy load balancing
+- **AWS Network Load Balancer (NLB)**: For RabbitMQ traffic distribution
+- **Security Groups**: For network access control
+- **CloudWatch Agent**: For monitoring and logging
+- **Bastion Host**: For secure access to private instances
+
+## OCI Equivalent Architecture
+
+The OCI setup maintains the same functionality with these equivalent components:
+
+| AWS Component | OCI Equivalent | Notes |
+|---------------|----------------|-------|
+| EC2 Instances | Compute Instances | Using VM.Standard.E4.Flex shapes |
+| VPC | Virtual Cloud Network (VCN) | |
+| Availability Zones | Availability Domains | |
+| Security Groups | Network Security Groups (NSG) | |
+| Network Load Balancer | Load Balancer (Flexible shape) | |
+| CloudWatch Agent | OCI Monitoring Agent | Custom monitoring setup |
+| AMI | Oracle Linux 8 Image | Using Oracle-provided images |
+| EBS Volumes | Block Volumes | Encrypted by default |
+
+## Key Changes Made
+
+### 1. Provider Configuration
+```hcl
+# Before (AWS)
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67"
+    }
+  }
+}
+
+# After (OCI)
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.26.0"
+    }
+  }
+}
+```
+
+### 2. Resource Mappings
+
+#### Compute Instances
+- **AWS**: `aws_instance` → **OCI**: `oci_core_instance`
+- Added shape configuration with OCPU and memory specifications
+- Changed from key pairs to SSH authorized keys in metadata
+
+#### Networking
+- **AWS**: `aws_security_group` → **OCI**: `oci_core_network_security_group`
+- **AWS**: Inline ingress/egress rules → **OCI**: Separate `oci_core_network_security_group_security_rule` resources
+
+#### Load Balancing
+- **AWS**: `aws_lb` (NLB) → **OCI**: `oci_load_balancer` (Flexible)
+- **AWS**: Target Groups → **OCI**: Backend Sets
+- **AWS**: Target Group Attachments → **OCI**: Backend resources
+
+### 3. Variable Updates
+
+Global variables updated to OCI terminology:
+- `vpc_id` → `vcn_id`
+- `account_id` → `compartment_id`
+- `availability_zones` → `availability_domains`
+
+### 4. Image and Instance Configuration
+
+- **AMI**: Changed from Ubuntu AMI to Oracle Linux 8 image OCID
+- **User**: Changed from `ubuntu` to `opc` (Oracle Public Cloud default user)
+- **Instance Types**: Mapped AWS instance types to OCI shapes:
+  - `t3a.medium` → `VM.Standard.E4.Flex` (2 OCPU, 16GB RAM)
+  - `r6a.xlarge` → `VM.Standard.E4.Flex` (4 OCPU, 32GB RAM)
+  - `r6a.large` → `VM.Standard.E4.Flex` (2 OCPU, 16GB RAM)
+
+### 5. Monitoring Setup
+
+- Replaced CloudWatch Agent with OCI Monitoring Agent
+- Updated configuration paths and service management
+- Modified Ansible playbooks for OCI-compatible monitoring setup
+
+## Configuration Steps
+
+### 1. Prerequisites
+
+1. **OCI Account**: Ensure you have an active OCI tenancy
+2. **OCI CLI**: Install and configure OCI CLI with appropriate credentials
+3. **Terraform**: Version >= 1.2.0
+4. **Network Setup**: Pre-existing VCN with subnets in multiple availability domains
+5. **SSH Keys**: Generate SSH key pair for instance access
+
+### 2. Configure Variables
+
+1. Copy the example variables file:
+   ```bash
+   cp infrastructure/global/cges/production/global_variables.tfvars.example \
+      infrastructure/global/cges/production/global_variables.tfvars
+   ```
+
+2. Fill in the required values:
+   - `region`: Your OCI region (e.g., "us-ashburn-1")
+   - `compartment_id`: Target compartment OCID
+   - `vcn_id`: Virtual Cloud Network OCID
+   - `availability_domains`: List of subnet OCIDs across ADs
+   - `bastion_ip`: IP of your bastion host
+   - `bastion_key`: Path to SSH private key
+
+### 3. OCI Authentication
+
+Set up OCI authentication using one of these methods:
+
+#### Option A: OCI CLI Config
+```bash
+oci setup config
+```
+
+#### Option B: Environment Variables
+```bash
+export TF_VAR_tenancy_ocid="ocid1.tenancy.oc1..."
+export TF_VAR_user_ocid="ocid1.user.oc1..."
+export TF_VAR_fingerprint="your:key:fingerprint"
+export TF_VAR_private_key_path="/path/to/private/key"
+```
+
+### 4. Deploy Infrastructure
+
+```bash
+cd infrastructure/global/cges/production
+terraform init
+terraform plan -var-file="global_variables.tfvars"
+terraform apply -var-file="global_variables.tfvars"
+```
+
+## Security Considerations
+
+### Network Security Groups (NSG)
+The following ports are configured:
+
+**Redis NSG**:
+- Port 22: SSH from bastion host
+- Port 6379: Redis communication from application subnets
+- Port 16379: Redis cluster communication
+
+**RabbitMQ NSG**:
+- Port 22: SSH from bastion host
+- Port 5672: RabbitMQ AMQP (via HAProxy)
+- Port 5673: Direct RabbitMQ AMQP
+- Port 7000: HAProxy statistics
+- Port 15672: RabbitMQ Management UI (via HAProxy)
+- Port 15673: Direct RabbitMQ Management UI
+
+### Encryption
+- All block volumes are encrypted by default
+- Network traffic encryption in transit is enabled
+- SSH keys are used for instance access (no passwords)
+
+## Monitoring and Logging
+
+### OCI Monitoring Integration
+- Custom namespace: `custom_metrics`
+- Metrics collected: CPU, Memory, Disk, Network
+- Collection interval: 60 seconds
+- System logs forwarded to OCI Logging service
+
+### Available Metrics
+- CPU usage (idle, user, system)
+- Memory utilization percentage
+- Disk usage percentage
+- Network connections (established, time_wait)
+
+## Load Balancer Configuration
+
+### RabbitMQ Load Balancer
+- **Type**: Flexible Load Balancer (private)
+- **Bandwidth**: 10-100 Mbps (auto-scaling)
+- **Health Checks**: TCP on ports 5672 and 15672
+- **Backend Policy**: Round Robin
+- **Listeners**: 
+  - Port 5672: RabbitMQ AMQP traffic
+  - Port 15672: Management UI traffic
+
+## Differences from AWS Implementation
+
+1. **Availability Domains**: OCI uses ADs instead of AZs, requiring explicit subnet specification
+2. **Flexible Shapes**: OCI allows custom OCPU/memory configuration vs fixed AWS instance types
+3. **NSG Rules**: OCI requires separate rule resources vs inline AWS security group rules
+4. **Load Balancer**: OCI uses unified load balancer vs separate NLB/ALB in AWS
+5. **Monitoring**: Custom OCI monitoring setup vs managed CloudWatch service
+6. **Image Management**: Using Oracle-provided images vs custom AMIs
+
+## Cost Optimization
+
+- **Flexible Shapes**: Right-size compute resources based on actual requirements
+- **Burstable Performance**: Utilize baseline performance with bursting capabilities
+- **Reserved Instances**: Consider OCI Reserved Capacity for predictable workloads
+- **Storage Optimization**: Use appropriate block volume performance tiers
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**:
+   - Verify OCI CLI configuration: `oci iam user get --user-id $OCI_USER_OCID`
+   - Check policy permissions for the compartment
+
+2. **Network Connectivity**:
+   - Verify subnet configuration and route tables
+   - Check NSG rules and security lists
+   - Ensure internet gateway/NAT gateway setup for outbound access
+
+3. **Instance Launch Failures**:
+   - Verify compartment quotas and limits
+   - Check availability domain capacity
+   - Ensure SSH key format is correct
+
+4. **Load Balancer Issues**:
+   - Verify backend health checks
+   - Check security rules for health check traffic
+   - Ensure backends are in correct subnets
+
+### Support Resources
+
+- **OCI Documentation**: https://docs.oracle.com/en-us/iaas/
+- **Terraform OCI Provider**: https://registry.terraform.io/providers/oracle/oci/
+- **OCI Community**: https://cloudcustomerconnect.oracle.com/
+
+## Migration Validation
+
+After deployment, validate the migration by:
+
+1. **Connectivity Tests**: Verify SSH access through bastion host
+2. **Service Health**: Check Redis cluster formation and RabbitMQ clustering
+3. **Load Balancer**: Test traffic distribution and health checks
+4. **Monitoring**: Confirm metrics collection and alerting
+5. **High Availability**: Test failover scenarios
+
+## Rollback Plan
+
+If rollback to AWS is needed:
+1. Restore original AWS configuration files from version control
+2. Update variable files with AWS-specific values
+3. Re-deploy using AWS provider
+4. Migrate data from OCI to AWS if necessary
+
+---
+
+**Note**: This migration maintains functional equivalence while leveraging OCI-native services and capabilities. All original functionality including high availability, load balancing, monitoring, and security controls are preserved in the OCI implementation.

--- a/infrastructure/common/cloudwatchagent/config.json
+++ b/infrastructure/common/cloudwatchagent/config.json
@@ -1,16 +1,19 @@
 {
-        "agent": {
-                "metrics_collection_interval": 60,
-                "run_as_user": "root"
+        "oci": {
+                "region": "auto",
+                "compartment_id": "auto"
         },
         "metrics": {
-                "append_dimensions": {
-                        "AutoScalingGroupName": "${aws:AutoScalingGroupName}",
-                        "ImageId": "${aws:ImageId}",
-                        "InstanceId": "${aws:InstanceId}",
-                        "InstanceType": "${aws:InstanceType}"
-                },
+                "namespace": "custom_metrics",
                 "metrics_collected": {
+                        "cpu": {
+                                "measurement": [
+                                        "cpu_usage_idle",
+                                        "cpu_usage_user",
+                                        "cpu_usage_system"
+                                ],
+                                "metrics_collection_interval": 60
+                        },
                         "disk": {
                                 "measurement": [
                                         "used_percent"
@@ -25,6 +28,26 @@
                                         "mem_used_percent"
                                 ],
                                 "metrics_collection_interval": 60
+                        },
+                        "netstat": {
+                                "measurement": [
+                                        "tcp_established",
+                                        "tcp_time_wait"
+                                ],
+                                "metrics_collection_interval": 60
+                        }
+                }
+        },
+        "logs": {
+                "logs_collected": {
+                        "files": {
+                                "collect_list": [
+                                        {
+                                                "file_path": "/var/log/messages",
+                                                "log_group_name": "system_logs",
+                                                "log_stream_name": "{instance_id}"
+                                        }
+                                ]
                         }
                 }
         }

--- a/infrastructure/common/cloudwatchagent/install_cloudwatch_agent.yaml
+++ b/infrastructure/common/cloudwatchagent/install_cloudwatch_agent.yaml
@@ -1,21 +1,35 @@
 ---
-- hosts: '{{ target }}'
+- hosts: "{{ target }}"
+  gather_facts: no
+  become: yes
   tasks:
-    - name: Download latest cloudwatch agent
-      become: true
-      shell: 
-        cmd: "wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb"
-      
-    - name: Install debian package
-      become: true
-      command: "dpkg -i -E ./amazon-cloudwatch-agent.deb"
+    - name: Download OCI Monitoring Agent
+      get_url:
+        url: "https://objectstorage.{{ ansible_default_ipv4.address | regex_replace('.*\\.(.*)\\.(.*)\\..*', '\\1-\\2') }}.oraclecloud.com/p/monitoring-agent/monitoring-agent-latest.tar.gz"
+        dest: /tmp/monitoring-agent-latest.tar.gz
+        mode: '0644'
 
-    - name: Copy config file
-      become: true
-      ansible.builtin.copy:
-        src: 'config.json'
-        dest: '{{ cloudwatch_agent_config_path }}'
+    - name: Extract OCI Monitoring Agent
+      unarchive:
+        src: /tmp/monitoring-agent-latest.tar.gz
+        dest: /opt/
+        remote_src: yes
+        creates: /opt/oracle/oci-monitoring-agent
 
-    - name: Reload the config file
-      become: true
-      command: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:{{ cloudwatch_agent_config_path }} -s"
+    - name: Create monitoring agent directory
+      file:
+        path: /opt/oracle/oci-monitoring-agent/bin
+        state: directory
+        mode: '0755'
+
+    - name: Copy monitoring agent config
+      copy:
+        src: "{{ cloudwatch_agent_config_path }}"
+        dest: /opt/oracle/oci-monitoring-agent/bin/config.json
+        mode: '0644'
+
+    - name: Install and start OCI monitoring agent service
+      systemd:
+        name: oci-monitoring-agent
+        state: started
+        enabled: yes

--- a/infrastructure/deploy-oci.sh
+++ b/infrastructure/deploy-oci.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# OCI Infrastructure Deployment Script
+# This script helps deploy the RabbitMQ and Redis infrastructure on OCI
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/global/cges/production"
+TFVARS_FILE="global_variables.tfvars"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    # Check if terraform is installed
+    if ! command -v terraform &> /dev/null; then
+        log_error "Terraform is not installed. Please install Terraform >= 1.2.0"
+        exit 1
+    fi
+    
+    # Check terraform version
+    TERRAFORM_VERSION=$(terraform version -json | jq -r '.terraform_version')
+    log_info "Terraform version: $TERRAFORM_VERSION"
+    
+    # Check if OCI CLI is installed
+    if ! command -v oci &> /dev/null; then
+        log_warning "OCI CLI is not installed. You may need to configure OCI authentication manually."
+    else
+        log_info "OCI CLI is available"
+    fi
+    
+    # Check if tfvars file exists
+    if [[ ! -f "${TERRAFORM_DIR}/${TFVARS_FILE}" ]]; then
+        log_error "Variables file not found: ${TERRAFORM_DIR}/${TFVARS_FILE}"
+        log_info "Please copy and configure the example file:"
+        log_info "  cp ${TERRAFORM_DIR}/${TFVARS_FILE}.example ${TERRAFORM_DIR}/${TFVARS_FILE}"
+        log_info "  # Edit the file with your OCI configuration"
+        exit 1
+    fi
+    
+    log_success "Prerequisites check completed"
+}
+
+terraform_init() {
+    log_info "Initializing Terraform..."
+    cd "${TERRAFORM_DIR}"
+    terraform init
+    log_success "Terraform initialized"
+}
+
+terraform_plan() {
+    log_info "Creating Terraform plan..."
+    cd "${TERRAFORM_DIR}"
+    terraform plan -var-file="${TFVARS_FILE}" -out=tfplan
+    log_success "Terraform plan created (saved as tfplan)"
+}
+
+terraform_apply() {
+    log_info "Applying Terraform configuration..."
+    cd "${TERRAFORM_DIR}"
+    
+    if [[ -f "tfplan" ]]; then
+        terraform apply tfplan
+    else
+        log_warning "No plan file found, running apply with auto-approve"
+        terraform apply -var-file="${TFVARS_FILE}" -auto-approve
+    fi
+    
+    log_success "Infrastructure deployed successfully!"
+    
+    # Show outputs
+    log_info "Infrastructure outputs:"
+    terraform output
+}
+
+terraform_destroy() {
+    log_warning "This will destroy ALL infrastructure resources!"
+    read -p "Are you sure you want to continue? (type 'yes' to confirm): " confirm
+    
+    if [[ $confirm == "yes" ]]; then
+        log_info "Destroying infrastructure..."
+        cd "${TERRAFORM_DIR}"
+        terraform destroy -var-file="${TFVARS_FILE}"
+        log_success "Infrastructure destroyed"
+    else
+        log_info "Destroy cancelled"
+    fi
+}
+
+show_help() {
+    echo "OCI Infrastructure Deployment Script"
+    echo ""
+    echo "Usage: $0 [COMMAND]"
+    echo ""
+    echo "Commands:"
+    echo "  init     - Initialize Terraform"
+    echo "  plan     - Create Terraform plan"
+    echo "  apply    - Apply Terraform configuration"
+    echo "  destroy  - Destroy infrastructure"
+    echo "  check    - Check prerequisites only"
+    echo "  help     - Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0 check      # Check prerequisites"
+    echo "  $0 init       # Initialize Terraform"
+    echo "  $0 plan       # Create deployment plan"
+    echo "  $0 apply      # Deploy infrastructure"
+    echo ""
+}
+
+# Main script logic
+case "${1:-help}" in
+    check)
+        check_prerequisites
+        ;;
+    init)
+        check_prerequisites
+        terraform_init
+        ;;
+    plan)
+        check_prerequisites
+        terraform_init
+        terraform_plan
+        ;;
+    apply)
+        check_prerequisites
+        terraform_init
+        terraform_apply
+        ;;
+    destroy)
+        check_prerequisites
+        terraform_destroy
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    *)
+        log_error "Unknown command: $1"
+        show_help
+        exit 1
+        ;;
+esac

--- a/infrastructure/global/cges/production/global_variables.tf
+++ b/infrastructure/global/cges/production/global_variables.tf
@@ -6,7 +6,7 @@ variable "global" {
     product            = string
     team               = string
     region             = string
-    vpc_id             = string
+    vcn_id             = string
     cidr_blocks        = list(string)
     bastion_ip         = string
     bastion_name       = string
@@ -14,11 +14,11 @@ variable "global" {
     bastion_key        = string
     bastion_sg_id      = string
     bastion_role_name  = string
-    account_id         = string
+    compartment_id     = string
     cygnet_cidr_blocks = list(string)
-    availability_zones = list(string)
-    public_availability_zones   = list(string)
-    eks_availability_zones      = list(string)
+    availability_domains = list(string)
+    public_availability_domains   = list(string)
+    eks_availability_domains      = list(string)
     s3_role                     = string
     cloudwatch_role             = string   
   })

--- a/infrastructure/global/cges/production/global_variables.tfvars.example
+++ b/infrastructure/global/cges/production/global_variables.tfvars.example
@@ -1,0 +1,45 @@
+global = {
+  country            = "YOUR_COUNTRY"
+  environment        = "production"
+  organization       = "YOUR_ORGANIZATION"
+  product            = "cges"
+  team               = "YOUR_TEAM"
+  region             = "YOUR_OCI_REGION"                      # e.g., "us-ashburn-1", "uk-london-1"
+  vcn_id             = "YOUR_VCN_OCID"                       # OCI VCN OCID
+  cidr_blocks        = ["YOUR_VCN_CIDR"]                     # e.g., ["10.0.0.0/16"]
+  bastion_ip         = "YOUR_BASTION_IP/32"                  # e.g., "10.0.1.10/32"
+  bastion_name       = "YOUR_BASTION_KEY_NAME"               # SSH key name for bastion access
+  bastion_user       = "opc"                                 # Default user for Oracle Linux
+  bastion_key        = "~/.ssh/your_private_key.pem"        # Path to your SSH private key
+  bastion_sg_id      = "YOUR_BASTION_NSG_OCID"              # Network Security Group OCID for bastion
+  bastion_role_name  = "YOUR_BASTION_ROLE"                  # IAM role for bastion host
+  compartment_id     = "YOUR_COMPARTMENT_OCID"              # OCI Compartment OCID where resources will be created
+  cygnet_cidr_blocks = ["YOUR_APPLICATION_CIDR"]            # e.g., ["10.0.2.0/24"]
+  availability_domains = [                                   # List of subnet OCIDs in different ADs
+    "YOUR_SUBNET_OCID_AD1",                                  # Subnet OCID in first availability domain
+    "YOUR_SUBNET_OCID_AD2",                                  # Subnet OCID in second availability domain
+    "YOUR_SUBNET_OCID_AD3"                                   # Subnet OCID in third availability domain
+  ]
+  public_availability_domains = [                            # Public subnet OCIDs if needed
+    "YOUR_PUBLIC_SUBNET_OCID_AD1",
+    "YOUR_PUBLIC_SUBNET_OCID_AD2",
+    "YOUR_PUBLIC_SUBNET_OCID_AD3"
+  ]
+  eks_availability_domains = [                               # For future OKE (Oracle Kubernetes Engine) use
+    "YOUR_OKE_SUBNET_OCID_AD1",
+    "YOUR_OKE_SUBNET_OCID_AD2",
+    "YOUR_OKE_SUBNET_OCID_AD3"
+  ]
+  s3_role                     = "YOUR_STORAGE_ROLE"          # OCI Object Storage role/policy
+  cloudwatch_role             = "YOUR_MONITORING_ROLE"      # OCI Monitoring role/policy
+}
+
+# Example values for reference:
+# region = "us-ashburn-1"
+# vcn_id = "ocid1.vcn.oc1.iad.aaaaaaaa..."
+# compartment_id = "ocid1.compartment.oc1..aaaaaaaa..."
+# availability_domains = [
+#   "ocid1.subnet.oc1.iad.aaaaaaaa...",  # AD-1 subnet
+#   "ocid1.subnet.oc1.iad.bbbbbbbb...",  # AD-2 subnet  
+#   "ocid1.subnet.oc1.iad.cccccccc..."   # AD-3 subnet
+# ]

--- a/infrastructure/global/cges/production/main.tf
+++ b/infrastructure/global/cges/production/main.tf
@@ -1,23 +1,23 @@
 terraform {
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.67"
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.26.0"
     }
   }
 
   required_version = ">= 1.2.0"
 }
 
-provider "aws" {
+provider "oci" {
   region = var.global.region
 }
 
 module "redis" {
-  source = "../../../modules/redis/v1"
+  source = "../../../modules/redis/v3"
   global = var.global
   input = {
-    instance_type = "t3a.medium"
+    instance_type = "VM.Standard.E4.Flex"
     password      = "cygnetaspredisclusterproduction"
     volume_size   = 24
     disable_api_termination = true
@@ -26,12 +26,12 @@ module "redis" {
 }
 
 module "rabbitmq_ha" {
-  source = "../../../modules/rabbitmq_single_node_ha/v3"
+  source = "../../../modules/rabbitmq_single_node_ha/v4"
   global = var.global
   input = {
     product                               = null
-    instance_type                         = "r6a.xlarge"
-    standby_instance_type                 = "r6a.large"
+    instance_type                         = "VM.Standard.E4.Flex"
+    standby_instance_type                 = "VM.Standard.E4.Flex"
     termination_protection                = false
     initial_configuration_path            = "rabbitmq/initial_configuration.json"
     linux_configuration_path              = "../../../common/linux/create_swap_memory.yaml"

--- a/infrastructure/modules/rabbitmq_single_node_ha/v4/global_variables.tf
+++ b/infrastructure/modules/rabbitmq_single_node_ha/v4/global_variables.tf
@@ -1,16 +1,17 @@
 variable "global" {
   type = object({
-    environment        = string
-    product            = string
-    team               = string
-    region             = string
-    vpc_id             = string
-    cidr_blocks        = list(string)
-    bastion_ip         = string
-    bastion_name       = string
-    bastion_user       = string
-    bastion_key        = string
-    availability_zones = list(string)
+    environment          = string
+    product              = string
+    team                 = string
+    region               = string
+    vcn_id               = string
+    cidr_blocks          = list(string)
+    bastion_ip           = string
+    bastion_name         = string
+    bastion_user         = string
+    bastion_key          = string
+    availability_domains = list(string)
+    compartment_id       = string
   })
   description = "Pass global variables file as terraform command argument. Example -var-file=\"../global/{product}/global_variables.tfvars\""
 }

--- a/infrastructure/modules/rabbitmq_single_node_ha/v4/local_variables.tf
+++ b/infrastructure/modules/rabbitmq_single_node_ha/v4/local_variables.tf
@@ -1,22 +1,30 @@
 locals {
   product = var.input.product == null ? var.global.product : var.input.product
   rabbitmq = {
-    ami                             = "ami-0e35ddab05955cf57"
-    volume_type                     = "gp3"
+    image_id                        = "ocid1.image.oc1..aaaaaaaahlnuhlmtlhap6pikl6stxnlmgfgp5jy5rexbnpmj3xboz4zo45lq"  # Oracle Linux 8
     encrypted                       = true
-    ebs_optimized                   = true
-    initial_configuration_path      = "/home/ubuntu/initial_configuration.json"
-    cloudwatch_agent_config_path    = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+    initial_configuration_path      = "/home/opc/initial_configuration.json"
+    cloudwatch_agent_config_path    = "/opt/oracle/oci-monitoring-agent/bin/config.json"
+    ocpus = {
+      1 = 4
+      2 = 2
+    }
+    memory_in_gbs = {
+      1 = 32
+      2 = 16
+    }
     instances = {
       1 = {
-        name          = "${local.product}-${var.global.environment}-EC2-RabbitMQ-HA-001-001-${var.input.version}"
-        instance_type = var.input.instance_type
-        subnet_id     = var.global.availability_zones[0]
+        name                = "${local.product}-${var.global.environment}-Compute-RabbitMQ-HA-001-001-${var.input.version}"
+        instance_type       = var.input.instance_type
+        subnet_id           = var.global.availability_domains[0]
+        availability_domain = var.global.availability_domains[0]
       }
       2 = {
-        name          = "${local.product}-${var.global.environment}-EC2-RabbitMQ-HA-002-001-${var.input.version}"
-        instance_type = var.input.standby_instance_type
-        subnet_id     = var.global.availability_zones[1]
+        name                = "${local.product}-${var.global.environment}-Compute-RabbitMQ-HA-002-001-${var.input.version}"
+        instance_type       = var.input.standby_instance_type
+        subnet_id           = var.global.availability_domains[1]
+        availability_domain = var.global.availability_domains[1]
       }
     }
   }

--- a/infrastructure/modules/redis/v3/global_variables.tf
+++ b/infrastructure/modules/redis/v3/global_variables.tf
@@ -1,16 +1,17 @@
 variable "global" {
   type = object({
-    environment        = string
-    product            = string
-    team               = string
-    region             = string
-    vpc_id             = string
-    cidr_blocks        = list(string)
-    bastion_ip         = string
-    bastion_name       = string
-    bastion_user       = string
-    bastion_key        = string
-    availability_zones = list(string)
+    environment          = string
+    product              = string
+    team                 = string
+    region               = string
+    vcn_id               = string
+    cidr_blocks          = list(string)
+    bastion_ip           = string
+    bastion_name         = string
+    bastion_user         = string
+    bastion_key          = string
+    availability_domains = list(string)
+    compartment_id       = string
   })
   description = "Pass global variables file as terraform command argument. Example -var-file=\"../global/{product}/global_variables.tfvars\""
 }

--- a/infrastructure/modules/redis/v3/local_variables.tf
+++ b/infrastructure/modules/redis/v3/local_variables.tf
@@ -1,36 +1,42 @@
 locals {
   product = var.input.product == null ? var.global.product : var.input.product
   redis = {
-    ami                           = "ami-0f5ee92e2d63afc18"
-    volume_type                   = "gp3"
+    image_id                      = "ocid1.image.oc1..aaaaaaaahlnuhlmtlhap6pikl6stxnlmgfgp5jy5rexbnpmj3xboz4zo45lq"  # Oracle Linux 8
+    ocpus                         = 2
+    memory_in_gbs                 = 16
     encrypted                     = true
-    ebs_optimized                 = true
-    linux_configuration_path      = "/home/ubuntu/create_swap_memory.yaml"
-    cloudwatch_agent_config_path  = "/opt/aws/amazon-cloudwatch-agent/bin/config.json"
+    linux_configuration_path      = "/home/opc/create_swap_memory.yaml"
+    cloudwatch_agent_config_path  = "/opt/oracle/oci-monitoring-agent/bin/config.json"
     instances = {
       0 = {
-        name      = "${local.product}-${var.global.environment}-EC2-Redis-001-001"
-        subnet_id = var.global.availability_zones[0]
+        name                = "${local.product}-${var.global.environment}-Compute-Redis-001-001"
+        subnet_id           = var.global.availability_domains[0]
+        availability_domain = var.global.availability_domains[0]
       }
       1 = {
-        name      = "${local.product}-${var.global.environment}-EC2-Redis-002-001"
-        subnet_id = var.global.availability_zones[1]
+        name                = "${local.product}-${var.global.environment}-Compute-Redis-002-001"
+        subnet_id           = var.global.availability_domains[1]
+        availability_domain = var.global.availability_domains[1]
       }
       2 = {
-        name      = "${local.product}-${var.global.environment}-EC2-Redis-003-001"
-        subnet_id = var.global.availability_zones[2]
+        name                = "${local.product}-${var.global.environment}-Compute-Redis-003-001"
+        subnet_id           = var.global.availability_domains[2]
+        availability_domain = var.global.availability_domains[2]
       }
       3 = {
-        name      = "${local.product}-${var.global.environment}-EC2-Redis-003-002"
-        subnet_id = var.global.availability_zones[0]
+        name                = "${local.product}-${var.global.environment}-Compute-Redis-003-002"
+        subnet_id           = var.global.availability_domains[0]
+        availability_domain = var.global.availability_domains[0]
       }
       4 = {
-        name      = "${local.product}-${var.global.environment}-EC2-Redis-001-002"
-        subnet_id = var.global.availability_zones[1]
+        name                = "${local.product}-${var.global.environment}-Compute-Redis-001-002"
+        subnet_id           = var.global.availability_domains[1]
+        availability_domain = var.global.availability_domains[1]
       }
       5 = {
-        name      = "${local.product}-${var.global.environment}-EC2-Redis-002-002"
-        subnet_id = var.global.availability_zones[2]
+        name                = "${local.product}-${var.global.environment}-Compute-Redis-002-002"
+        subnet_id           = var.global.availability_domains[2]
+        availability_domain = var.global.availability_domains[2]
       }
     }
   }


### PR DESCRIPTION
Migrate the existing RabbitMQ and Redis infrastructure Terraform configuration from AWS to OCI, maintaining identical functionality.